### PR TITLE
force docker linux/amd64 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ tail -F ${HOME}/.local/state/hck/log/hckctl-*.log
 just publish <MAJOR.MINOR.PATCH>
 ```
 
+## Known issues
+
+* Most of the images are built by default only for [`linux/amd64`](https://github.com/hckops/hckctl/pull/169), but they should work also on `linux/arm64`
+
 ## Roadmap
 
 * `flow` orchestrate and schedule multistage tasks, collect and output the combined results in multiple formats

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/term v0.5.0
+	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.31.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
@@ -91,7 +92,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
 	github.com/opencontainers/runc v1.1.9 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/pkg/box/docker/docker.go
+++ b/pkg/box/docker/docker.go
@@ -136,6 +136,7 @@ func (box *DockerBoxClient) createBox(opts *boxModel.CreateOptions) (*boxModel.B
 		ContainerConfig:              containerConfig,
 		HostConfig:                   hostConfig,
 		NetworkingConfig:             docker.BuildNetworkingConfig(networkName, networkId), // all on the same network
+		Platform:                     docker.DefaultPlatform(),
 		WaitStatus:                   false,
 		CaptureInterrupt:             false,
 		OnContainerInterruptCallback: func(string) {},

--- a/pkg/client/docker/builder.go
+++ b/pkg/client/docker/builder.go
@@ -142,7 +142,7 @@ func BuildNetworkingConfig(networkName, networkId string) *network.NetworkingCon
 
 func DefaultPlatform() *ocispec.Platform {
 	return &ocispec.Platform{
-		Architecture: "amd64", // TODO add support for linux/arm64
+		Architecture: "amd64",
 		OS:           "linux",
 	}
 }

--- a/pkg/client/docker/builder.go
+++ b/pkg/client/docker/builder.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -137,4 +138,11 @@ func ContainerNetworkMode(idOrName string) string {
 
 func BuildNetworkingConfig(networkName, networkId string) *network.NetworkingConfig {
 	return &network.NetworkingConfig{EndpointsConfig: map[string]*network.EndpointSettings{networkName: {NetworkID: networkId}}}
+}
+
+func DefaultPlatform() *ocispec.Platform {
+	return &ocispec.Platform{
+		Architecture: "amd64", // TODO add support for linux/arm64
+		OS:           "linux",
+	}
 }

--- a/pkg/client/docker/builder.go
+++ b/pkg/client/docker/builder.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"fmt"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -11,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/hckops/hckctl/pkg/util"
 )

--- a/pkg/client/docker/builder_test.go
+++ b/pkg/client/docker/builder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestBuildContainerConfig(t *testing.T) {
@@ -136,4 +137,9 @@ func TestBuildNetworkingConfig(t *testing.T) {
 
 	result := BuildNetworkingConfig("myNetwork", "123")
 	assert.Equal(t, expected, result)
+}
+
+func TestDefaultPlatform(t *testing.T) {
+	expected := &ocispec.Platform{Architecture: "amd64", OS: "linux"}
+	assert.Equal(t, expected, DefaultPlatform())
 }

--- a/pkg/client/docker/client.go
+++ b/pkg/client/docker/client.go
@@ -19,8 +19,6 @@ import (
 	dockerApi "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/stdcopy"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	"github.com/hckops/hckctl/pkg/client/terminal"
 	"github.com/hckops/hckctl/pkg/util"
 )
@@ -86,18 +84,12 @@ func (client *DockerClient) ImageRemoveDangling(opts *ImageRemoveOpts) error {
 
 func (client *DockerClient) ContainerCreate(opts *ContainerCreateOpts) (string, error) {
 
-	// TODO move in ContainerCreateOpts and use this as default
-	platform := &ocispec.Platform{
-		Architecture: "amd64",
-		OS:           "linux",
-	}
-
 	newContainer, err := client.docker.ContainerCreate(
 		client.ctx,
 		opts.ContainerConfig,
 		opts.HostConfig,
 		opts.NetworkingConfig,
-		platform,
+		opts.Platform,
 		opts.ContainerName)
 	if err != nil {
 		return "", errors.Wrap(err, "error container create")

--- a/pkg/client/docker/client.go
+++ b/pkg/client/docker/client.go
@@ -19,6 +19,7 @@ import (
 	dockerApi "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/stdcopy"
+
 	"github.com/hckops/hckctl/pkg/client/terminal"
 	"github.com/hckops/hckctl/pkg/util"
 )

--- a/pkg/client/docker/client.go
+++ b/pkg/client/docker/client.go
@@ -19,6 +19,7 @@ import (
 	dockerApi "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/stdcopy"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/hckops/hckctl/pkg/client/terminal"
 	"github.com/hckops/hckctl/pkg/util"
@@ -85,12 +86,18 @@ func (client *DockerClient) ImageRemoveDangling(opts *ImageRemoveOpts) error {
 
 func (client *DockerClient) ContainerCreate(opts *ContainerCreateOpts) (string, error) {
 
+	// TODO move in ContainerCreateOpts and use this as default
+	platform := &ocispec.Platform{
+		Architecture: "amd64",
+		OS:           "linux",
+	}
+
 	newContainer, err := client.docker.ContainerCreate(
 		client.ctx,
 		opts.ContainerConfig,
 		opts.HostConfig,
 		opts.NetworkingConfig,
-		nil, // platform
+		platform,
 		opts.ContainerName)
 	if err != nil {
 		return "", errors.Wrap(err, "error container create")

--- a/pkg/client/docker/client.go
+++ b/pkg/client/docker/client.go
@@ -43,7 +43,7 @@ func (client *DockerClient) Close() error {
 
 func (client *DockerClient) ImagePull(opts *ImagePullOpts) error {
 
-	reader, err := client.docker.ImagePull(client.ctx, opts.ImageName, types.ImagePullOptions{})
+	reader, err := client.docker.ImagePull(client.ctx, opts.ImageName, types.ImagePullOptions{Platform: opts.PlatformString()})
 	if err != nil {
 		return errors.Wrap(err, "error image pull")
 	}
@@ -90,7 +90,7 @@ func (client *DockerClient) ContainerCreate(opts *ContainerCreateOpts) (string, 
 		opts.ContainerConfig,
 		opts.HostConfig,
 		opts.NetworkingConfig,
-		opts.Platform,
+		opts.Platform, // consistent with ImagePull, on ARM it works also if "nil"
 		opts.ContainerName)
 	if err != nil {
 		return "", errors.Wrap(err, "error container create")

--- a/pkg/client/docker/client_test.go
+++ b/pkg/client/docker/client_test.go
@@ -100,3 +100,10 @@ func TestNewContainerDetails(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, containerDetails)
 }
+
+func TestImagePlatform(t *testing.T) {
+	opts := &ImagePullOpts{
+		Platform: DefaultPlatform(),
+	}
+	assert.Equal(t, "linux/amd64", opts.PlatformString())
+}

--- a/pkg/client/docker/options.go
+++ b/pkg/client/docker/options.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/api/types/container"
@@ -34,7 +35,12 @@ type ContainerPortConfigOpts struct {
 
 type ImagePullOpts struct {
 	ImageName           string
+	Platform            *ocispec.Platform
 	OnImagePullCallback func()
+}
+
+func (o *ImagePullOpts) PlatformString() string {
+	return fmt.Sprintf("%s/%s", o.Platform.OS, o.Platform.Architecture)
 }
 
 type ImageRemoveOpts struct {

--- a/pkg/client/docker/options.go
+++ b/pkg/client/docker/options.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
 
 	"github.com/docker/docker/api/types/container"
@@ -46,6 +47,7 @@ type ContainerCreateOpts struct {
 	ContainerConfig              *container.Config
 	HostConfig                   *container.HostConfig
 	NetworkingConfig             *network.NetworkingConfig
+	Platform                     *ocispec.Platform
 	WaitStatus                   bool
 	CaptureInterrupt             bool
 	OnContainerInterruptCallback func(containerId string)

--- a/pkg/client/docker/options.go
+++ b/pkg/client/docker/options.go
@@ -1,11 +1,11 @@
 package docker
 
 import (
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	commonModel "github.com/hckops/hckctl/pkg/common/model"
 )

--- a/pkg/common/docker/client.go
+++ b/pkg/common/docker/client.go
@@ -150,6 +150,7 @@ func (common *DockerCommonClient) SidecarVpnInject(opts *commonModel.SidecarVpnI
 		ContainerName:    containerName,
 		ContainerConfig:  containerConfig,
 		HostConfig:       hostConfig,
+		Platform:         docker.DefaultPlatform(),
 		WaitStatus:       false,
 		CaptureInterrupt: false, // edge case: killing this while creating will leave an orphan sidecar container
 		OnContainerCreateCallback: func(containerId string) error {

--- a/pkg/common/docker/client.go
+++ b/pkg/common/docker/client.go
@@ -46,8 +46,15 @@ func (common *DockerCommonClient) Close() error {
 
 func (common *DockerCommonClient) PullImageOffline(imageName string, onImagePullCallback func()) error {
 
+	// TODO add support at least for linux/arm64
+	// temporary solution to force the architecture, ideally:
+	// - every image should be correctly built for all the architectures
+	// - the templates should have a field with the list of supported architectures and use the default only as fallback
+	platform := docker.DefaultPlatform()
+
 	imagePullOpts := &docker.ImagePullOpts{
 		ImageName:           imageName,
+		Platform:            platform,
 		OnImagePullCallback: onImagePullCallback,
 	}
 	common.eventBus.Publish(newImagePullDockerEvent(imageName))

--- a/pkg/common/docker/client.go
+++ b/pkg/common/docker/client.go
@@ -57,7 +57,7 @@ func (common *DockerCommonClient) PullImageOffline(imageName string, onImagePull
 		Platform:            platform,
 		OnImagePullCallback: onImagePullCallback,
 	}
-	common.eventBus.Publish(newImagePullDockerEvent(imageName))
+	common.eventBus.Publish(newImagePullDockerEvent(imageName, imagePullOpts.PlatformString()))
 	if err := common.client.ImagePull(imagePullOpts); err != nil {
 		// ignore error and try to use an existing image if exists
 		if common.clientOpts.IgnoreImagePullError {

--- a/pkg/common/docker/events.go
+++ b/pkg/common/docker/events.go
@@ -32,8 +32,8 @@ func newCloseDockerClientEvent() *dockerCommonEvent {
 	return &dockerCommonEvent{kind: event.LogDebug, value: "close docker client"}
 }
 
-func newImagePullDockerEvent(imageName string) *dockerCommonEvent {
-	return &dockerCommonEvent{kind: event.LogInfo, value: fmt.Sprintf("image pull: imageName=%s", imageName)}
+func newImagePullDockerEvent(imageName string, platform string) *dockerCommonEvent {
+	return &dockerCommonEvent{kind: event.LogInfo, value: fmt.Sprintf("image pull: imageName=%s platform=%s", imageName, platform)}
 }
 
 func newImagePullIgnoreDockerEvent(imageName string) *dockerCommonEvent {

--- a/pkg/task/docker/docker.go
+++ b/pkg/task/docker/docker.go
@@ -101,7 +101,8 @@ func (task *DockerTaskClient) runTask(opts *taskModel.RunOptions) error {
 		ContainerConfig:  containerConfig,
 		HostConfig:       hostConfig,
 		NetworkingConfig: docker.BuildNetworkingConfig(networkName, networkId), // all on the same network
-		WaitStatus:       true,                                                 // block
+		Platform:         docker.DefaultPlatform(),
+		WaitStatus:       true, // block
 		CaptureInterrupt: true,
 		OnContainerInterruptCallback: func(containerId string) {
 			// returns control to runTask, it will correctly invoke defer to remove the sidecar


### PR DESCRIPTION
temporary fix to support arm
```
2024-05-18T10:34:52+01:00 WRN internal/command/box/common.go:54 > error invoking client: provider=docker error="error container create: Error response from daemon: image with reference hckops/arch-tty:latest was found but does not match the specified platform: wanted linux/amd64, actual: linux/arm64" sessionId=v6xkp source=hckctl
```

how to test it
```bash
# build
just

# run
./build/hckctl box arch
```